### PR TITLE
[TESTS] Use init as provider for service[ssh] in kitchen-docker

### DIFF
--- a/libraries/node.rb
+++ b/libraries/node.rb
@@ -32,6 +32,10 @@ module Typo3
       def virtualized?
         return virtualization? && node[:virtualization][:role].eql?("guest")
       end
+
+      def in_docker?
+        return virtualized? && node[:virtualization][:system] == 'docker'
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, CI builds of t3-base fail with

> Errno::ENOENT: No such file or directory - /sbin/status

The reason for this is that Chef Client picks the wrong provider for
the service[ssh] resource inside of the docker container.

/sbin/status comes from upstart and we can also see in the stack trace
that it picked that provider. This is obviously wrong for Debian 8
(Debian 7 isn't affected by that bug).

Instead, it should pick SysVinit, which is implemented by
Chef::Provider::Service::Init::Debian.

Fixes: #1