### PR TITLE
[TASK] Pin systemd cookbook to 2.1.3 #patch

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -39,6 +39,7 @@ depends "ntp",          "= 1.8.6"
 depends "openssh",      "= 2.1.0"
 depends "postfix",      "= 3.7.0"
 depends "sudo",         "= 2.6.0"
+depends "systemd",      "= 2.1.3"
 depends "users",        "= 2.0.3"
 
 # For compatibility with Chef 12.5.1


### PR DESCRIPTION
This is needed because breaking changes in the systemd 3.0 cookbook.

For example, systemd::logind is now a resource and needs to be adjusted
for the new version...