### PR TITLE
[TASK] Allow setting of DEBIAN_FRONTEND with sudo #patch

### DIFF
--- a/attributes/sudo.rb
+++ b/attributes/sudo.rb
@@ -3,6 +3,6 @@ default['authorization']['sudo']['include_sudoers_d'] = true
 #<> Set up `secure_path`, otherwise $PATH will be very short after sudo'ing
 default['authorization']['sudo']['sudoers_defaults'] = [
   'env_reset',
-  'env_keep+="SSH_AUTH_SOCK"',
+  'env_keep+="SSH_AUTH_SOCK DEBIAN_FRONTEND"',
   'secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"'
 ]


### PR DESCRIPTION
This allows us to run `sudo DEBIAN_FRONTEND=noninteractive apt-get -yqq upgrade`.

Without this change, the command fails:
```
$ sudo DEBIAN_FRONTEND=noninteractive apt-get -yqq upgrade         
sudo: sorry, you are not allowed to set the following environment variables: DEBIAN_FRONTEND
```