### PR TITLE
Use mailrelay.typo3.org for outgoing emails

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,14 +17,24 @@ suites:
     run_list:
       - recipe[t3-base::default]
     attributes:
+      postfix:
+        main:
+          relayhost: mailrelay.invalid
   - name: physical
     run_list:
       - recipe[t3-base::default]
       - recipe[t3-base::_physical]
+    attributes:
+      postfix:
+        main:
+          relayhost: mailrelay.invalid
   - name: production
     run_list:
       - recipe[t3-base::default]
     attributes:
+      postfix:
+        main:
+          relayhost: mailrelay.invalid
       t3-base:
         flags:
           production: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'berkshelf', git: 'git@github.com:berkshelf/berkshelf.git'
+gem 'solve', git: 'git@github.com:berkshelf/solve.git'
+

--- a/attributes/postfix.rb
+++ b/attributes/postfix.rb
@@ -6,3 +6,6 @@ default['postfix']['aliases']['root'] = "admin@typo3.org"
 
 #<> Some applications try to send mails from root@localhost, which are not accepted by the mail server. Rewrite those to root@typo3.org
 default['postfix']['smtp_generic_map_entries'] = { "@localhost" => "@typo3.org" }
+
+#<> Relay outgoing mail via mailrelay.typo3.org (which then use mail.typo3.org)
+default['postfix']['main']['relayhost'] = 'mailrelay.typo3.org'

--- a/test/integration/data_bags/datacenters/test.json
+++ b/test/integration/data_bags/datacenters/test.json
@@ -4,11 +4,6 @@
     "test.vagrant"
   ],
   "attributes": {
-    "postfix": {
-      "main": {
-        "relayhost": "test.example.com"
-      }
-    },
     "ntp": {
       "servers": [
         "0.0.0.0",

--- a/test/integration/production/inspec/production_spec.rb
+++ b/test/integration/production/inspec/production_spec.rb
@@ -5,10 +5,6 @@ control 't3base-production-1' do
     so that we seem to be in the "test" data center.
     Now check that the attributes defined for this DC are set.
   '
-  describe file('/etc/postfix/main.cf') do
-    its('content') { should match /relayhost = test.example.com/ }
-  end
-
   describe file('/etc/aliases') do
     its('content') { should match /johnsysadmin:\s+john@example.org/}
   end
@@ -24,4 +20,7 @@ control 't3base-production-2' do
     its('content') { should match %r{^AVOID_DAILY_AUTOCOMMITS=1$} }
   end
 
+  describe parse_config_file('/etc/postfix/main.cf') do
+    its('relayhost') { should include 'mailrelay.invalid'}
+  end
 end


### PR DESCRIPTION
Outgoing emails should be sent via mail.typo3.org to add DKIM signatures
and to reduce the SPF-whitelisted hosts.

To avoid storing credentials on every single node, we have the
mail relays (site-mailrelaytypo3org), which can authenticate against
mail.typo3.org and forwards mails for us without authentication
(from the private network only, dude ;-))