### PR TITLE
Revert "[TASK] Add dirmngr for Debian 9"

### DIFF
--- a/recipes/_software.rb
+++ b/recipes/_software.rb
@@ -27,7 +27,6 @@ end
 
 # Debian Stretch needs some packages which are no longer installed by default
 stretch_packages = %w{
-  dirmngr
   gnupg
 }
 


### PR DESCRIPTION
This reverts commit 065024036122ef76e6d6b560274a7ed076f1f2e0.

We noticed that dirmngr, once used, creates a huge number of processes
that keep running.

It looks like this is a known issue, see
- https://tickets.puppetlabs.com/browse/MODULES-5533
- https://bugs.launchpad.net/ubuntu/+source/gnupg2/+bug/1626646

For now, dirmngr will be removed again. If any system needs it (it is used
for adding apt-keys) then this should be done manually for now...